### PR TITLE
Basic認証を本番環境でのみ実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,17 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
+  protect_from_forgery with: :exception
 
   private
+
+  def production?
+    Rails.env.production?
+  end
 
   # Basic認証
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == 'admin' && password == '2222'
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
   end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -52,6 +52,10 @@
 server '3.114.129.44',
   user: "ec2-user",
   roles: %w{app db web}
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
+
 #   ssh_options: {
 #     user: "user_name", # overrides user setting above
 #     keys: %w(/home/user_name/.ssh/id_rsa),


### PR DESCRIPTION
# What
Basic環境を本番環境のみで実装するために、環境変数の設定とunicornに本番環境と認識させるコードを追加

# Why
開発環境でもBasic認証を一々要求されると煩わしいため