### PR TITLE
都道府県データをactive_hashを使って管理

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,4 +2,8 @@ class Address < ApplicationRecord
   has_one :product
 
   validates :postal_code, :city, :address, :prefecture, presence: true
+
+  # active_hashで都道府県データを導入する
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,20 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -158,6 +158,10 @@
             %div
               .select-wrap
                 %select{class:"select-wrap__defaultcategory"}
+                -# active_hashは導入してあります。
+                -# 参照：https://kossy-web-engineer.hatenablog.com/entry/2019/01/08/205702
+                -# form_for使い始めたら使う
+                -# = f.collection_select :prefecture_id, Prefecture.all, :id, :name
                   %option{value: 0} ---
                 %i.far.fa-angle-down
           .form-group.top-margin


### PR DESCRIPTION
# what
active_hashを導入して都道府県名を数値で管理できる。
prefectureモデルの作成
addressモデルにactive_hashを利用したprefectureデータの取得を記述

# why
prefectureテーブルが必要なくなる