### PR TITLE
brand_idのバリデーションの削除

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :images
   belongs_to :user
   belongs_to :category
-  validates :name, :postage_id, :price, :description, :shipping_date_id, :shipping_method_id, :condition_id, :size_id, :category_id, :brand_id, :prefecture_id, presence: true
+  validates :name, :postage_id, :price, :description, :shipping_date_id, :shipping_method_id, :condition_id, :size_id, :category_id, :prefecture_id, presence: true
 
   def self.search(search)
     return Product.all unless search


### PR DESCRIPTION
# What
product.rbからbrand_idのバリデーション削除

# Why
brand_idをバリデーションから外すことで、商品出品時にブランドを選ばなくてもエラーが起きなくなるため。