### PR TITLE
ユーザー商品出品一覧の表示をユーザーと紐づいたものが表示されるよう修正

### DIFF
--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -223,6 +223,7 @@
         }
       }
       .btn--red {
+        cursor: pointer;
         margin: 40px 0 0;
         background: #ea352d;
         border: 1px solid #ea352d;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user
-  before_action :set_product, only: [:show, :edit, :display]
-
+  before_action :set_product, only: [:show, :edit]
+  before_action :set_image
   
   def index
   end
@@ -16,6 +16,7 @@ class UsersController < ApplicationController
   end
 
   def display
+    @products = Product.where(id: current_user.id)
   end
 # スプリントレビュー後削除、ここから
   def logout
@@ -58,4 +59,7 @@ class UsersController < ApplicationController
     @products = Product.all
   end
  
+  def set_image
+    @images = Image.where(product_id:params[:id])
+  end
 end


### PR DESCRIPTION
#What
今まで全ての出品情報が表示されていた部分もログインユーザーのものだけ表示されるように修正

#Why
他のユーザーが出品した商品も全て見えてしまっていたため